### PR TITLE
[Version/1.0.0] SubwayInfoDataError 발생 시 에러처리

### DIFF
--- a/SubwayTalking/SubwayTalking/Source/Data/Repository/DefaultMarkerDataRepository.swift
+++ b/SubwayTalking/SubwayTalking/Source/Data/Repository/DefaultMarkerDataRepository.swift
@@ -11,12 +11,12 @@ import RxSwift
 
 final class DefaultMarkerDataRepository: MarkerDataRepository {
     func fetchData() -> Single<[SubwayInformation]> {
-        return Single<[SubwayInformation]>.create { single in
+        return Single<[SubwayInformation]>.create { observer in
             do {
                 let subwayInformations = try self.decodeSubwayData()
-                single(.success(subwayInformations))
+                observer(.success(subwayInformations))
             } catch {
-                single(.failure(error))
+                observer(.failure(error))
             }
             
             return Disposables.create()

--- a/SubwayTalking/SubwayTalking/Source/Domain/UseCase/AddMarkerUseCase.swift
+++ b/SubwayTalking/SubwayTalking/Source/Domain/UseCase/AddMarkerUseCase.swift
@@ -9,7 +9,7 @@ import RxSwift
 import Foundation
 
 protocol AddMarkerUseCase {
-    func fetchMarkerData() -> Observable<[SubwayInformation]>
+    func fetchMarkerData() -> Single<[SubwayInformation]>
 }
 
 final class DefaultAddMarkerUseCase: AddMarkerUseCase {
@@ -19,11 +19,10 @@ final class DefaultAddMarkerUseCase: AddMarkerUseCase {
         self.markerDataRepository = markerDataRepository
     }
     
-    func fetchMarkerData() -> Observable<[SubwayInformation]> {
+    func fetchMarkerData() -> Single<[SubwayInformation]> {
         return markerDataRepository.fetchData()
             .map({ infos in
                 return infos.filter { $0.latitude != .zero && $0.longitude != .zero }
             })
-            .asObservable()
     }
 }

--- a/SubwayTalking/SubwayTalking/Source/Presentation/MainScene/Intent/MainIntent.swift
+++ b/SubwayTalking/SubwayTalking/Source/Presentation/MainScene/Intent/MainIntent.swift
@@ -19,10 +19,6 @@ protocol MainIntent {
 
 final class DefaultMainIntent: MainIntent {
     
-    deinit {
-        print("DefaultMainIntent DEINIT")
-    }
-    
     // MARK: Property
     
     private let state: StateRelay<MainState>

--- a/SubwayTalking/SubwayTalking/Source/Presentation/MainScene/Intent/MainState.swift
+++ b/SubwayTalking/SubwayTalking/Source/Presentation/MainScene/Intent/MainState.swift
@@ -15,6 +15,7 @@ struct MainState: State {
     let location: CLLocation
     let userLocationMoveFlag: Bool
     let cameraLocationAddress: String
+    let error: Error?
     
     init(
         prevState: MainState? = nil,
@@ -22,12 +23,14 @@ struct MainState: State {
         authRequestFlag: Bool? = false,
         location: CLLocation? = nil,
         userLocationMoveFlag: Bool? = false,
-        cameraLocationAddress: String? = nil
+        cameraLocationAddress: String? = nil,
+        error: Error? = nil
     ) {
         self.subwayInfos = subwayInfos.isEmpty ? (prevState?.subwayInfos ?? []) : subwayInfos
         self.authRequestFlag = authRequestFlag ?? prevState?.authRequestFlag ?? false
         self.location = location ?? prevState?.location ?? CLLocation()
         self.userLocationMoveFlag = userLocationMoveFlag ?? prevState?.userLocationMoveFlag ?? false
         self.cameraLocationAddress = cameraLocationAddress ?? prevState?.cameraLocationAddress ?? ""
+        self.error = error
     }
 }

--- a/SubwayTalking/SubwayTalking/Source/Presentation/MainScene/View/MainViewController.swift
+++ b/SubwayTalking/SubwayTalking/Source/Presentation/MainScene/View/MainViewController.swift
@@ -153,6 +153,10 @@ final class MainViewController: UIViewController, MainViewUpdatable {
         if state.cameraLocationAddress != prev.cameraLocationAddress {
             addressLabel.text = state.cameraLocationAddress
         }
+         
+        if state.error != nil {
+            showAlert(title: Constant.Text.alertErrorTitle, message: state.error?.localizedDescription ?? "")
+        }
     }
 }
 

--- a/SubwayTalking/SubwayTalking/Source/Presentation/Protocol/Alertable.swift
+++ b/SubwayTalking/SubwayTalking/Source/Presentation/Protocol/Alertable.swift
@@ -31,4 +31,20 @@ extension Alertable where Self: UIViewController {
         [confirmAction, cancelAction].forEach { alert.addAction($0) }
         present(alert, animated: true)
     }
+    
+    func showAlert(title: String, message: String) {
+        let alert = UIAlertController(
+            title: title,
+            message: message,
+            preferredStyle: .alert
+        )
+        
+        let confirmAction = UIAlertAction(
+            title: Constant.Text.alertCancelActionTitle,
+            style: .default
+        )
+        
+        alert.addAction(confirmAction)
+        present(alert, animated: true)
+    }
 }

--- a/SubwayTalking/SubwayTalking/Source/Util/Constant/Constant.swift
+++ b/SubwayTalking/SubwayTalking/Source/Util/Constant/Constant.swift
@@ -15,6 +15,8 @@ enum Constant {
         static let locationAlertTitle = "현재 위치를 불러올 수 없습니다."
         static let locationAlertMessage = "위치 서비스를 사용하실 수 없습니다.\n디바이스의 '설정 > 개인정보 보호'에서 위치 서비스를 켜주세요."
         static let locationAlertConfirmActionTitle = "설정으로 이동"
+        
+        static let alertErrorTitle = "오류발생"
         static let alertCancelActionTitle = "취소"
         static let converteAddressFail = "위치정보가 없습니다."
         


### PR DESCRIPTION
## 구현 사항
### 1. SubwayInfo JsonData Decode 과정에 Error 발생 시, Error Alert 표시
- SubwayData Decode한 결과가 담긴 Single 처리를 subscribe(onError:)를 통해 처리
- Error 발생 시, [Error, nil]을 순차적으로 state 주입 및 생성하여 Accept

## 고민 사항
### Zip vs CombineLatest vs 분리
- Decode 결과를 담은 Single과 Address 결과가 담긴 Observable을 하나의 스트림으로 합치는 과정에서 zip과 combineLatest 중 고민하였으며, Decode 결과를 담은 Single은 단 한번만 방출하기 때문에 zip을 선택하였었습니다. 
하지만, 두 Observable이 하나의 스트림으로 합칠 이유가 없고, 별개로 동작하고 처리해야하기 때문에 분리하였습니다.